### PR TITLE
Support GraalVM 19.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM oracle/graalvm-ce:1.0.0-rc16 as graalvm
+FROM oracle/graalvm-ce:19.0.0 as graalvm
+RUN gu install native-image
 WORKDIR /work
 COPY ./target/micronaut-petclinic-*.jar .
 RUN native-image --no-server -cp micronaut-petclinic-*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <webjars-jquery.version>2.2.4</webjars-jquery.version>
     <wro4j.version>1.8.0</wro4j.version>
 
-    <substratevm.version>1.0.0-rc16</substratevm.version>
+    <substratevm.version>19.0.0</substratevm.version>
     <annotation-api.version>1.3.2</annotation-api.version>
     <xerces.version>2.12.0</xerces.version>
   </properties>

--- a/src/main/resources/META-INF/native-image/com.example.micronaut/petclinic-application/native-image.properties
+++ b/src/main/resources/META-INF/native-image/com.example.micronaut/petclinic-application/native-image.properties
@@ -1,4 +1,6 @@
 Args = -H:IncludeResources=application.yml|templates/.*|messages/.*|static.resources/.*|META-INF/resources/webjars/.* \
        -H:Name=petclinic \
        -H:Class=com.example.micronaut.petclinic.PetClinicApplication \
-       --delay-class-initialization-to-runtime=org.apache.commons.logging.LogAdapter$Log4jLog,org.hibernate.secure.internal.StandardJaccServiceImpl,org.postgresql.sspi.SSPIClient,org.hibernate.dialect.OracleTypesHelper
+       --initialize-at-build-time \
+       --initialize-at-run-time=org.apache.commons.logging.LogAdapter$Log4jLog,org.hibernate.secure.internal.StandardJaccServiceImpl,org.postgresql.sspi.SSPIClient,org.hibernate.dialect.OracleTypesHelper \
+       --no-fallback


### PR DESCRIPTION
But it doesn't succeed to build native-image because we need this fix:
https://github.com/oracle/graal/commit/c6237d219a91c82b1954dfbfa0898ed917db09eb

When I build substratevm with that commit, it works to build native-image.
I'm currently waiting for the next release of GraalVM.